### PR TITLE
Destructor frees pio resources.

### DIFF
--- a/Adafruit_NeoPXL8.h
+++ b/Adafruit_NeoPXL8.h
@@ -179,6 +179,7 @@ protected:
   uint8_t sm;                    ///< State machine #
   int dma_channel;               ///< DMA channel #
   dma_channel_config dma_config; ///< DMA configuration
+  uint offset;
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
   gdma_channel_handle_t dma_chan; ///< DMA channel
   dma_descriptor_t *desc;         ///< DMA descriptor pointer


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.
The Adafruit_NeoPXL8 destructor was updated to remove the pio state machine claimed from the constructor. Also, the DMA channel is unclaimed, and the IRQ handler is removed.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.
No known limitations

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.
I've tested this myself, but I'd recommend testing against your own examples.
