### PR TITLE
Add RP235x to many RP2040 references in documentation & comments

### DIFF
--- a/Adafruit_NeoPXL8.cpp
+++ b/Adafruit_NeoPXL8.cpp
@@ -6,13 +6,13 @@
  * @file Adafruit_NeoPXL8.cpp
  *
  * @mainpage 8-way concurrent DMA NeoPixel library for SAMD21, SAMD51,
- * RP2040 and ESP32S3 microcontrollers.
+ * RP2040, RP235x, and ESP32S3 microcontrollers.
  *
  * @section intro_sec Introduction
  *
  * Adafruit_NeoPXL8 is an Arduino library that leverages hardware features
  * unique to some Atmel SAMD21 and SAMD51 microcontrollers, plus the
- * Raspberry Pi RP2040 and Espressif ESP32S3 (not S2, etc.) chips, to
+ * Raspberry Pi RP2040, RP235x, and Espressif ESP32S3 (not S2, etc.) chips, to
  * communicate with large numbers of NeoPixels with very low CPU utilization
  * and without losing track of time. It was originally designed for the
  * Adafruit Feather M0 board with NeoPXL8 FeatherWing interface/adapter,
@@ -41,9 +41,9 @@
  * gamma correction. This requires inordinate RAM, and the frequent need
  * for refreshing makes it best suited for multi-core chips (e.g. RP2040).
  *
- * RP2040 support requires Philhower core (not Arduino mbed core).
- * Also on RP2040, pin numbers passed to constructor are GP## indices,
- * not necessarily the digital pin numbers silkscreened on the board.
+ * RP2040 and RP235x support requires Philhower core (not Arduino mbed core).
+ * Also on RP2040 and RP235x, pin numbers passed to constructor are GP##
+ * indices, not necessarily the digital pin numbers silkscreened on the board.
  *
  * 0/1 bit timing does not precisely match NeoPixel/WS2812/SK6812 datasheet
  * specs, but it seems to work well enough. Use at your own peril.
@@ -109,6 +109,7 @@ Adafruit_NeoPXL8::Adafruit_NeoPXL8(uint16_t n, int8_t *p, neoPixelType t)
 static Adafruit_NeoPXL8 *neopxl8_ptr = NULL;
 
 #if defined(ARDUINO_ARCH_RP2040)
+// note that ARDUINO_ARCH_RP2040 blocks also apply to RP235x
 
 #define DMA_IRQ_N 1 ///< Can be 0 or 1, no functional difference, 1 looks cool
 
@@ -1295,7 +1296,7 @@ DMA-capable peripherals is exploited for byte-wide concurrent output
 (specifically the TCC0 pattern generator, which is normally used for
 motor control or some such). Although SAMD51 does have PORT DMA, the
 pattern generator approach is used there regardless, so similar code
-can be used for both chips. On RP2040, PIO code is used.
+can be used for both chips. On RP2040 and RP235x, PIO code is used.
 
 To issue 8 bits in parallel, all bytes of NeoPixel data must be "turned
 sideways" in RAM so all the bit 7's are issued concurrently, then all

--- a/Adafruit_NeoPXL8.h
+++ b/Adafruit_NeoPXL8.h
@@ -5,8 +5,8 @@
 /*!
  * @file Adafruit_NeoPXL8.h
  *
- * 8-way concurrent DMA NeoPixel library for SAMD21, SAMD51, RP2040, and
- * ESP32S3 microcontrollers.
+ * 8-way concurrent DMA NeoPixel library for SAMD21, SAMD51, RP2040, RP235x,
+ * and ESP32S3 microcontrollers.
  *
  * Adafruit invests time and resources providing this open source code,
  * please support Adafruit and open-source hardware by purchasing
@@ -63,8 +63,8 @@ public:
             mind that this will always still use the same amount of memory
             as 8-way output. If unspecified (or if NULL is passed), a
             default 8-pin setup will be used (see example sketch).
-            On RP2040, these are GP## numbers, not necessarily the digital
-            pin numbers silkscreened on the board.
+            On RP2040 and RP235x, these are GP## numbers, not necessarily the
+            digital pin numbers silkscreened on the board.
     @param  t
             NeoPixel color data order, same as in Adafruit_NeoPixel library
             (optional, default is GRB).
@@ -207,7 +207,7 @@ protected:
          additions for 16-bits-per-channel color, temporal dithering,
          frame blending and gamma correction. This requires inordinate RAM,
          and the frequent need for refreshing makes it best suited for
-         multi-core chips (e.g. RP2040).
+         multi-core chips (e.g. RP2040, RP235x).
 */
 class Adafruit_NeoPXL8HDR : public Adafruit_NeoPXL8 {
 
@@ -227,8 +227,8 @@ public:
             mind that this will always still use the same amount of memory
             as 8-way output. If unspecified (or if NULL is passed), a
             default 8-pin setup will be used (see example sketch).
-            On RP2040, these are GP## numbers, not necessarily the digital
-            pin numbers silkscreened on the board.
+            On RP2040 and RP235x, these are GP## numbers, not necessarily the
+            digital pin numbers silkscreened on the board.
     @param  t
             NeoPixel color data order, same as in Adafruit_NeoPixel library
             (optional, default is GRB).
@@ -242,7 +242,7 @@ public:
                    refresh() function between show() calls (uses more RAM).
                    If false (default), no blending. This is useful ONLY if
                    sketch can devote time to many refresh() calls, e.g. on
-                   multicore RP2040.
+                   multicore RP2040 or RP235x.
     @param  bits   Number of bits for temporal dithering, 0-8. Higher values
                    provide more intermediate shades but slower refresh;
                    dither becomes more apparent. Default is 4, providing
@@ -506,8 +506,8 @@ public:
   /*!
     @brief   Query overall display refresh rate in frames-per-second.
              This is only an estimate and requires a moment to stabilize;
-             will initially be 0. It's really only helpful on RP2040 where
-             the refresh loop runs full-tilt on its own core; on SAMD,
+             will initially be 0. It's really only helpful on RP2040 and RP235x
+             where the refresh loop runs full-tilt on its own core; on SAMD,
              refresh is handled with a fixed timer interrupt.
     @return  Integer frames (pixel refreshes) per second.
   */

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Adafruit_NeoPXL8
-DMA-driven 8-way concurrent NeoPixel driver for SAMD21 (M0+), SAMD51 (M4), RP2040 and ESP32S3 microcontrollers. Requires latest Adafruit_NeoPixel and Adafruit_ZeroDMA libraries.
+DMA-driven 8-way concurrent NeoPixel driver for SAMD21 (M0+), SAMD51 (M4), RP2040, RP235x, and ESP32S3 microcontrollers. Requires latest Adafruit_NeoPixel and Adafruit_ZeroDMA libraries.
 
 (Pronounced "NeoPixelate")
 
@@ -42,12 +42,12 @@ Other boards (such as Grand Central) have an altogether different pinout. See th
 
 Pin MUXing is a hairy thing and over time we'll try to build up some ready-to-use examples for different boards and peripherals. You can also try picking your way through the SAMD21/51 datasheet or the NeoPXL8 source code for pin/peripheral assignments.
 
-On RP2040 boards, the pins can be within any 8-pin range (e.g. 0-7, or 4-11, etc.). If using fewer than 8 outputs, they do not need to be contiguous, but the lowest and highest pin number must still be within 8-pin range.
+On RP2040 and RP235x boards, the pins can be within any 8-pin range (e.g. 0-7, or 4-11, etc.). If using fewer than 8 outputs, they do not need to be contiguous, but the lowest and highest pin number must still be within 8-pin range.
 
 On ESP32S3 boards, go wild...there are no pin restrictions.
 
 ## NeoPXL8HDR
 
-Adafruit_NeoPXL8HDR is a subclass of Adafruit_NeoPXL8 with additions for 16-bit color, temporal dithering, gamma correction and frame blending. This requires inordinate RAM, and the need for frequent refreshing makes it best suited for multi-core chips (e.g. RP2040).
+Adafruit_NeoPXL8HDR is a subclass of Adafruit_NeoPXL8 with additions for 16-bit color, temporal dithering, gamma correction and frame blending. This requires inordinate RAM, and the need for frequent refreshing makes it best suited for multi-core chips (e.g. RP2040 and RP235x).
 
 See examples/NeoPXL8HDR/strandtest for use.


### PR DESCRIPTION
I compiled the basic strand demo and uploaded it to a Pico 2 board. I didn't hook up LEDs but I used Saleae's WS2812B decoder and saw valid & plausible data on Pico 2 pins 0 through 7 inclusive.

ping @ladyada @FeuerSturm