### PR TITLE
Fix high-numbered RP2350's

### DIFF
--- a/Adafruit_NeoPXL8.h
+++ b/Adafruit_NeoPXL8.h
@@ -81,11 +81,7 @@ public:
                   NeoPXL8HDR's use. Currently ignored on SAMD.
     @return true on successful alloc/init, false otherwise.
   */
-#if defined(ARDUINO_ARCH_RP2040)
-  bool begin(bool dbuf = false, PIO pio_instance = pio0);
-#else
   bool begin(bool dbuf = false);
-#endif
 
   /*!
     @brief  Process and issue new data to the NeoPixel strands.
@@ -175,11 +171,11 @@ public:
 
 protected:
 #if defined(ARDUINO_ARCH_RP2040)
-  PIO pio;                       ///< PIO peripheral
-  uint8_t sm;                    ///< State machine #
+  PIO pio = NULL;                ///< PIO peripheral
+  uint sm = -1;                  ///< State machine #
+  uint offset = 0;
   int dma_channel;               ///< DMA channel #
   dma_channel_config dma_config; ///< DMA configuration
-  uint offset;
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
   gdma_channel_handle_t dma_chan; ///< DMA channel
   dma_descriptor_t *desc;         ///< DMA descriptor pointer
@@ -253,12 +249,7 @@ public:
                    others just waste RAM. Currently ignored on SAMD.
     @return true on successful alloc/init, false otherwise.
   */
-#if defined(ARDUINO_ARCH_RP2040)
-  bool begin(bool blend = false, uint8_t bits = 4, bool dbuf = false,
-             PIO pio_instance = pio0);
-#else
   bool begin(bool blend = false, uint8_t bits = 4, bool dbuf = false);
-#endif
 
   /*!
     @brief  Set peak output brightness for all channels (RGB and W if

--- a/Adafruit_NeoPXL8.h
+++ b/Adafruit_NeoPXL8.h
@@ -171,8 +171,8 @@ public:
 
 protected:
 #if defined(ARDUINO_ARCH_RP2040)
-  PIO pio = NULL;                ///< PIO peripheral
-  uint sm = -1;                  ///< State machine #
+  PIO pio = NULL; ///< PIO peripheral
+  uint sm = -1;   ///< State machine #
   uint offset = 0;
   int dma_channel;               ///< DMA channel #
   dma_channel_config dma_config; ///< DMA configuration
@@ -533,7 +533,7 @@ protected:
 #if defined(ARDUINO_ARCH_RP2040)
   mutex_t mutex; ///< For synchronizing cores
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-  SemaphoreHandle_t mutex; ///< For synchronizing cores
+  SemaphoreHandle_t mutex;        ///< For synchronizing cores
 #endif
 };
 

--- a/Adafruit_NeoPXL8.h
+++ b/Adafruit_NeoPXL8.h
@@ -533,7 +533,7 @@ protected:
 #if defined(ARDUINO_ARCH_RP2040)
   mutex_t mutex; ///< For synchronizing cores
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-  SemaphoreHandle_t mutex;        ///< For synchronizing cores
+  SemaphoreHandle_t mutex; ///< For synchronizing cores
 #endif
 };
 

--- a/examples/NeoPXL8/VideoMSC/VideoMSC.ino
+++ b/examples/NeoPXL8/VideoMSC/VideoMSC.ino
@@ -7,6 +7,7 @@
 // This is a companion to "move2msc" in the extras/Processing folder.
 // It plays preconverted videos from the on-board flash filesystem.
 
+#include "SdFat_Adafruit_Fork.h"
 #include <Adafruit_NeoPXL8.h>
 #include <Adafruit_CPFS.h> // For accessing CIRCUITPY drive
 #define ARDUINOJSON_ENABLE_COMMENTS 1

--- a/examples/NeoPXL8/VideoSerial/VideoSerial.ino
+++ b/examples/NeoPXL8/VideoSerial/VideoSerial.ino
@@ -6,6 +6,7 @@
 
 // This is a companion to "move2serial" in the extras/Processing folder.
 
+#include "SdFat_Adafruit_Fork.h"
 #include <Adafruit_NeoPXL8.h>
 #include <Adafruit_CPFS.h> // For accessing CIRCUITPY drive
 #define ARDUINOJSON_ENABLE_COMMENTS 1

--- a/examples/NeoPXL8HDR/VideoMSC/VideoMSC.ino
+++ b/examples/NeoPXL8HDR/VideoMSC/VideoMSC.ino
@@ -8,6 +8,7 @@
 // This is a companion to "move2msc" in the extras/Processing folder.
 // It plays preconverted videos from the on-board flash filesystem.
 
+#include "SdFat_Adafruit_Fork.h"
 #include <Adafruit_NeoPXL8.h>
 #include <Adafruit_CPFS.h> // For accessing CIRCUITPY drive
 #define ARDUINOJSON_ENABLE_COMMENTS 1

--- a/examples/NeoPXL8HDR/VideoSerial/VideoSerial.ino
+++ b/examples/NeoPXL8HDR/VideoSerial/VideoSerial.ino
@@ -7,6 +7,7 @@
 
 // This is a companion to "move2serial" in the extras/Processing folder.
 
+#include "SdFat_Adafruit_Fork.h"
 #include <Adafruit_NeoPXL8.h>
 #include <Adafruit_CPFS.h> // For accessing CIRCUITPY drive
 #define ARDUINOJSON_ENABLE_COMMENTS 1


### PR DESCRIPTION
Fix high-numbered RP2350's, also removed the 'fixed' pio argument, we will pick the next available PIO with space (which means we can also select pio2 automatically on rp2350)

this is a breaking change because we now no longer have a 'different' begin() to manually select a pio

needs testing on a SCORPIO, tested on fruit jam